### PR TITLE
Update td-hm_hrnet-w32_udp-8xb64-250e-512x512_AdaptiveWingLoss.py

### DIFF
--- a/cldetection_configs/td-hm_hrnet-w32_udp-8xb64-250e-512x512_AdaptiveWingLoss.py
+++ b/cldetection_configs/td-hm_hrnet-w32_udp-8xb64-250e-512x512_AdaptiveWingLoss.py
@@ -7,6 +7,7 @@ default_hooks = dict(
     checkpoint=dict(
         type='CheckpointHook',
         interval=2,
+        max_keep_ckpts=5,
         save_best='SDR 2.0mm',
         rule='greater'),
     sampler_seed=dict(type='DistSamplerSeedHook'),


### PR DESCRIPTION
add `max_keep_ckpts=5,` in default_hooks to save disk space of saved ckpt model